### PR TITLE
Problem: fireEvents not run asynchronously

### DIFF
--- a/.changelog/unreleased/improvements/4-async-fire-events.md
+++ b/.changelog/unreleased/improvements/4-async-fire-events.md
@@ -1,0 +1,3 @@
+- `[consensus]` run fireEvents in goroutine.
+  ([#4](https://github.com/crypto-org-chain/cometbft/pull/4))
+

--- a/state/execution.go
+++ b/state/execution.go
@@ -315,9 +315,11 @@ func (blockExec *BlockExecutor) applyBlock(state State, blockID types.BlockID, b
 		}
 	}
 
-	// Events are fired after everything else.
-	// NOTE: if we crash between Commit and Save, events wont be fired during replay
-	fireEvents(blockExec.logger, blockExec.eventBus, block, blockID, abciResponse, validatorUpdates)
+	if _, ok := blockExec.eventBus.(types.NopEventBus); !ok {
+		// Events are fired after everything else.
+		// NOTE: if we crash between Commit and Save, events wont be fired during replay
+		go fireEvents(blockExec.logger, blockExec.eventBus, block, blockID, abciResponse, validatorUpdates)
+	}
 
 	return state, nil
 }


### PR DESCRIPTION
`fireEvents` is quite heavy when block is big, and should be fine to run asynchronously.

<img width="467" alt="截屏2024-11-01 14 54 11" src="https://github.com/user-attachments/assets/b5f0d073-158c-4566-9ca1-fe10ebf821a5">


<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
