### PR TITLE
Problem: check tx don't need to hold mempool lock

### DIFF
--- a/.changelog/unreleased/improvements/7-release-mempool-lock.md
+++ b/.changelog/unreleased/improvements/7-release-mempool-lock.md
@@ -1,0 +1,2 @@
+- `[mempool]` relase lock earlier in CheckTx
+  ([#7](https://github.com/crypto-org-chain/cometbft/pull/7))


### PR DESCRIPTION
Solution:
- release the lock earlier, mainly for local client

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
