### PR TITLE
fix: flaky TestByzantinePrevoteEquivocation and psql Docker port conflict

### DIFF
--- a/.changelog/unreleased/bug-fixes/30-fix-flaky-tests.md
+++ b/.changelog/unreleased/bug-fixes/30-fix-flaky-tests.md
@@ -1,0 +1,6 @@
+- `[consensus]` Fix flaky `TestByzantinePrevoteEquivocation` by removing
+  hardcoded 20s timeout in favor of the test's `-timeout` flag.
+  ([#30](https://github.com/crypto-org-chain/cometbft/pull/30))
+- `[state/indexer]` Fix psql test Docker port conflict by using explicit
+  random host port binding.
+  ([#30](https://github.com/crypto-org-chain/cometbft/pull/30))

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -268,27 +268,21 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		}(i)
 	}
 
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
 	pubkey, err := bcs.privValidator.GetPubKey()
 	require.NoError(t, err)
 
-	select {
-	case <-done:
-		for idx, ev := range evidenceFromEachValidator {
-			if assert.NotNil(t, ev, idx) {
-				ev, ok := ev.(*types.DuplicateVoteEvidence)
-				assert.True(t, ok)
-				assert.Equal(t, pubkey.Address(), ev.VoteA.ValidatorAddress)
-				assert.Equal(t, prevoteHeight, ev.Height())
-			}
+	// Wait for all validators to observe evidence. Relies on the test's
+	// -timeout flag (default 10m) rather than an arbitrary short deadline
+	// that can flake in slow CI environments.
+	wg.Wait()
+
+	for idx, ev := range evidenceFromEachValidator {
+		if assert.NotNil(t, ev, idx) {
+			ev, ok := ev.(*types.DuplicateVoteEvidence)
+			assert.True(t, ok)
+			assert.Equal(t, pubkey.Address(), ev.VoteA.ValidatorAddress)
+			assert.Equal(t, prevoteHeight, ev.Height())
 		}
-	case <-time.After(20 * time.Second):
-		t.Fatalf("Timed out waiting for validators to commit evidence")
 	}
 }
 

--- a/state/indexer/sink/psql/psql_test.go
+++ b/state/indexer/sink/psql/psql_test.go
@@ -73,6 +73,11 @@ func TestMain(m *testing.M) {
 		config.RestartPolicy = docker.RestartPolicy{
 			Name: "no",
 		}
+		// Bind container port to a random available host port to avoid
+		// conflicts with a local PostgreSQL or parallel test runs.
+		config.PortBindings = map[docker.Port][]docker.PortBinding{
+			docker.Port(port + "/tcp"): {{HostPort: "0"}},
+		}
 	})
 	if err != nil {
 		log.Fatalf("Starting docker pool: %v", err)

--- a/state/indexer/sink/psql/psql_test.go
+++ b/state/indexer/sink/psql/psql_test.go
@@ -67,17 +67,22 @@ func TestMain(m *testing.M) {
 			"listen_addresses = '*'",
 		},
 		ExposedPorts: []string{port},
+		// Bind container port to a random available host port to avoid
+		// "address already in use" when port 5432 is taken by a local
+		// PostgreSQL or a parallel test run.
+		PortBindings: map[docker.Port][]docker.PortBinding{
+			docker.Port(port + "/tcp"): {{HostPort: ""}},
+		},
 	}, func(config *docker.HostConfig) {
 		// set AutoRemove to true so that stopped container goes away by itself
 		config.AutoRemove = true
 		config.RestartPolicy = docker.RestartPolicy{
 			Name: "no",
 		}
-		// Bind container port to a random available host port to avoid
-		// conflicts with a local PostgreSQL or parallel test runs.
-		config.PortBindings = map[docker.Port][]docker.PortBinding{
-			docker.Port(port + "/tcp"): {{HostPort: "0"}},
-		}
+		// Disable PublishAllPorts so Docker only uses our explicit
+		// random-port binding above instead of also trying to publish
+		// all exposed ports (which can race on CI).
+		config.PublishAllPorts = false
 	})
 	if err != nil {
 		log.Fatalf("Starting docker pool: %v", err)


### PR DESCRIPTION
## Summary
- **Byzantine test**: Remove the hardcoded 20s `time.After` timeout in `TestByzantinePrevoteEquivocation` that flakes in slow CI environments. Use a blocking `wg.Wait()` instead, relying on the test's `-timeout` flag (default 10m) for the overall deadline.
- **psql test**: Explicitly bind the PostgreSQL Docker container port to a random available host port (`HostPort: "0"`) to avoid `address already in use` errors when port 5432 is occupied by a local PostgreSQL instance or a parallel test run.
