### PR TITLE
perf(mempool): replace proto marshaling with arithmetic in ComputeProtoSizeForTxs

### DIFF
--- a/.changelog/unreleased/improvements/32-perf-compute-proto-size.md
+++ b/.changelog/unreleased/improvements/32-perf-compute-proto-size.md
@@ -1,0 +1,4 @@
+- `[mempool]` Replace proto marshaling with direct arithmetic in
+  `ComputeProtoSizeForTxs`, eliminating per-tx allocations in the hot
+  `ReapMaxBytesMaxGas` path for ~2x speedup.
+  ([#32](https://github.com/crypto-org-chain/cometbft/pull/32))

--- a/mempool/bench_test.go
+++ b/mempool/bench_test.go
@@ -1,6 +1,7 @@
 package mempool
 
 import (
+	"fmt"
 	"sync/atomic"
 	"testing"
 
@@ -21,6 +22,26 @@ func BenchmarkReap(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		mp.ReapMaxBytesMaxGas(100_000_000, -1)
+	}
+}
+
+func BenchmarkReapMaxBytesMaxGas(b *testing.B) {
+	for _, numTxs := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("txs=%d", numTxs), func(b *testing.B) {
+			app := kvstore.NewInMemoryApplication()
+			cc := proxy.NewLocalClientCreator(app)
+			mp, cleanup := newMempoolWithApp(cc)
+			defer cleanup()
+
+			mp.config.Size = 100_000_000
+			addTxs(b, mp, 0, numTxs)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				mp.ReapMaxBytesMaxGas(100_000_000, -1)
+			}
+		})
 	}
 }
 

--- a/types/tx.go
+++ b/types/tx.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"math/bits"
 
 	"github.com/cometbft/cometbft/crypto/merkle"
 	"github.com/cometbft/cometbft/crypto/tmhash"
@@ -183,10 +184,26 @@ func TxProofFromProto(pb cmtproto.TxProof) (TxProof, error) {
 	return pbtp, nil
 }
 
-// ComputeProtoSizeForTxs wraps the transactions in cmtproto.Data{} and calculates the size.
+// ComputeProtoSizeForTxs returns the protobuf wire size that the given
+// transactions would occupy inside a cmtproto.Data message.
 // https://developers.google.com/protocol-buffers/docs/encoding
 func ComputeProtoSizeForTxs(txs []Tx) int64 {
-	data := Data{Txs: txs}
-	pdData := data.ToProto()
-	return int64(pdData.Size())
+	var size int64
+	for _, tx := range txs {
+		size += computeProtoSizeForTx(tx)
+	}
+	return size
+}
+
+// computeProtoSizeForTx returns the protobuf wire size of a single tx
+// in a Data.Txs repeated bytes field: tag (1 byte) + varint(len) + data.
+func computeProtoSizeForTx(tx Tx) int64 {
+	l := len(tx)
+	return 1 + int64(protoVarintSize(uint64(l))) + int64(l)
+}
+
+// protoVarintSize returns the number of bytes needed to encode x as a
+// protobuf unsigned varint.
+func protoVarintSize(x uint64) int {
+	return (bits.Len64(x|1) + 6) / 7
 }

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -149,3 +149,38 @@ func assertBadProof(t *testing.T, root []byte, bad []byte, good TxProof) {
 func randInt(low, high int) int {
 	return rand.Intn(high-low) + low
 }
+
+func TestComputeProtoSizeForTx(t *testing.T) {
+	// computeProtoSizeForTxs using the old protobuf-based method
+	oldComputeProtoSize := func(txs []Tx) int64 {
+		data := Data{Txs: txs}
+		pdData := data.ToProto()
+		return int64(pdData.Size())
+	}
+
+	tests := []struct {
+		name string
+		size int
+	}{
+		{"empty", 0},
+		{"1 byte", 1},
+		{"127 bytes (1-byte varint boundary)", 127},
+		{"128 bytes (2-byte varint boundary)", 128},
+		{"16383 bytes (2-byte varint boundary)", 16383},
+		{"16384 bytes (3-byte varint boundary)", 16384},
+		{"large tx (100KB)", 100_000},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := Tx(make([]byte, tc.size))
+			got := ComputeProtoSizeForTxs([]Tx{tx})
+			want := oldComputeProtoSize([]Tx{tx})
+			require.Equal(t, want, got, "mismatch for tx size %d", tc.size)
+		})
+	}
+
+	// Also verify multi-tx batches match.
+	txs := makeTxs(50, 200)
+	require.Equal(t, oldComputeProtoSize(txs), ComputeProtoSizeForTxs(txs))
+}


### PR DESCRIPTION
## Summary
Backport of [cometbft/cometbft#5694](https://github.com/cometbft/cometbft/pull/5694).

- `ComputeProtoSizeForTxs` previously allocated a `Data{}` struct and marshaled to protobuf per call, causing O(n) allocations in the hot `ReapMaxBytesMaxGas` path
- Replace with direct arithmetic (`tag byte + varint length + data`) that matches the protobuf wire format exactly
- Benchmarks show ~2x speedup and allocations drop from 1-per-tx to 1 total across all mempool sizes
