### PR TITLE
perf(consensus): dispatch fireEvents off consensus thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### IMPROVEMENTS
 
+- `[consensus]` perf(consensus): dispatch fireEvents off the consensus thread via a buffered task runner
+  ([\#45](https://github.com/crypto-org-chain/cometbft/pull/45))
 - `[blocksync]` validate blocksync response sender and signature count
   ([\#5860](https://github.com/cometbft/cometbft/pull/5860))
 

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -373,22 +373,24 @@ func subscribeToVoter(cs *State, addr []byte) <-chan cmtpubsub.Message {
 //-------------------------------------------------------------------------------
 // consensus states
 
-func newState(state sm.State, pv types.PrivValidator, app abci.Application) *State {
+func newState(t *testing.T, state sm.State, pv types.PrivValidator, app abci.Application) *State {
 	config := test.ResetTestRoot("consensus_state_test")
-	return newStateWithConfig(config, state, pv, app)
+	return newStateWithConfig(t, config, state, pv, app)
 }
 
 func newStateWithConfig(
+	t *testing.T,
 	thisConfig *cfg.Config,
 	state sm.State,
 	pv types.PrivValidator,
 	app abci.Application,
 ) *State {
 	blockDB := dbm.NewMemDB()
-	return newStateWithConfigAndBlockStore(thisConfig, state, pv, app, blockDB)
+	return newStateWithConfigAndBlockStore(t, thisConfig, state, pv, app, blockDB)
 }
 
 func newStateWithConfigAndBlockStore(
+	t *testing.T,
 	thisConfig *cfg.Config,
 	state sm.State,
 	pv types.PrivValidator,
@@ -442,6 +444,7 @@ func newStateWithConfigAndBlockStore(
 		panic(err)
 	}
 	cs.SetEventBus(eventBus)
+	t.Cleanup(cs.stopTaskRunner)
 	return cs
 }
 
@@ -454,26 +457,28 @@ func loadPrivValidator(config *cfg.Config) *privval.FilePV {
 	return privValidator
 }
 
-func randState(nValidators int) (*State, []*validatorStub) {
-	return randStateWithApp(nValidators, kvstore.NewInMemoryApplication())
+func randState(t *testing.T, nValidators int) (*State, []*validatorStub) {
+	return randStateWithApp(t, nValidators, kvstore.NewInMemoryApplication())
 }
 
 func randStateWithAppWithHeight(
+	t *testing.T,
 	nValidators int,
 	app abci.Application,
 	height int64,
 ) (*State, []*validatorStub) {
 	c := test.ConsensusParams()
 	c.ABCI.VoteExtensionsEnableHeight = height
-	return randStateWithAppImpl(nValidators, app, c)
+	return randStateWithAppImpl(t, nValidators, app, c)
 }
 
-func randStateWithApp(nValidators int, app abci.Application) (*State, []*validatorStub) {
+func randStateWithApp(t *testing.T, nValidators int, app abci.Application) (*State, []*validatorStub) {
 	c := test.ConsensusParams()
-	return randStateWithAppImpl(nValidators, app, c)
+	return randStateWithAppImpl(t, nValidators, app, c)
 }
 
 func randStateWithAppImpl(
+	t *testing.T,
 	nValidators int,
 	app abci.Application,
 	consensusParams *types.ConsensusParams,
@@ -483,7 +488,7 @@ func randStateWithAppImpl(
 
 	vss := make([]*validatorStub, nValidators)
 
-	cs := newState(state, privVals[0], app)
+	cs := newState(t, state, privVals[0], app)
 
 	for i := 0; i < nValidators; i++ {
 		vss[i] = newValidatorStub(privVals[i], int32(i))
@@ -792,7 +797,7 @@ func randConsensusNet(t *testing.T, nValidators int, testName string, tickerFunc
 		_, err := app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
 		require.NoError(t, err)
 
-		css[i] = newStateWithConfigAndBlockStore(thisConfig, state, privVals[i], app, stateDB)
+		css[i] = newStateWithConfigAndBlockStore(t, thisConfig, state, privVals[i], app, stateDB)
 		css[i].SetTimeoutTicker(tickerFunc())
 		css[i].SetLogger(logger.With("validator", i, "module", "consensus"))
 	}
@@ -856,7 +861,7 @@ func randConsensusNetWithPeers(
 		_, err := app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
 		require.NoError(t, err)
 
-		css[i] = newStateWithConfig(thisConfig, state, privVal, app)
+		css[i] = newStateWithConfig(t, thisConfig, state, privVal, app)
 		css[i].SetTimeoutTicker(tickerFunc())
 		css[i].SetLogger(logger.With("validator", i, "module", "consensus"))
 	}

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -34,7 +34,7 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 	resp, err := app.Info(context.Background(), proxy.RequestInfo)
 	require.NoError(t, err)
 	state.AppHash = resp.LastBlockAppHash
-	cs := newStateWithConfig(config, state, privVals[0], app)
+	cs := newStateWithConfig(t, config, state, privVals[0], app)
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
@@ -58,7 +58,7 @@ func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {
 	resp, err := app.Info(context.Background(), proxy.RequestInfo)
 	require.NoError(t, err)
 	state.AppHash = resp.LastBlockAppHash
-	cs := newStateWithConfig(config, state, privVals[0], app)
+	cs := newStateWithConfig(t, config, state, privVals[0], app)
 
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 
@@ -75,7 +75,7 @@ func TestMempoolProgressInHigherRound(t *testing.T) {
 	defer os.RemoveAll(config.RootDir)
 	config.Consensus.CreateEmptyBlocks = false
 	state, privVals := randGenesisState(1, false, 10, nil)
-	cs := newStateWithConfig(config, state, privVals[0], kvstore.NewInMemoryApplication())
+	cs := newStateWithConfig(t, config, state, privVals[0], kvstore.NewInMemoryApplication())
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
@@ -119,7 +119,7 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	state, privVals := randGenesisState(1, false, 10, nil)
 	blockDB := dbm.NewMemDB()
 	stateStore := sm.NewStore(blockDB, sm.StoreOptions{DiscardABCIResponses: false})
-	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], kvstore.NewInMemoryApplication(), blockDB)
+	cs := newStateWithConfigAndBlockStore(t, config, state, privVals[0], kvstore.NewInMemoryApplication(), blockDB)
 	err := stateStore.Save(state)
 	require.NoError(t, err)
 	newBlockEventsCh := subscribe(cs.eventBus, types.EventQueryNewBlockEvents)
@@ -145,7 +145,7 @@ func TestMempoolRmBadTx(t *testing.T) {
 	app := kvstore.NewInMemoryApplication()
 	blockDB := dbm.NewMemDB()
 	stateStore := sm.NewStore(blockDB, sm.StoreOptions{DiscardABCIResponses: false})
-	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], app, blockDB)
+	cs := newStateWithConfigAndBlockStore(t, config, state, privVals[0], app, blockDB)
 	err := stateStore.Save(state)
 	require.NoError(t, err)
 

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -354,7 +354,7 @@ func TestSwitchToConsensusVoteExtensions(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			ctx := t.Context()
 
-			cs, vs := randState(1)
+			cs, vs := randState(t, 1)
 			validator := vs[0]
 			validator.Height = testCase.storedHeight
 
@@ -1145,7 +1145,7 @@ func TestMarshalJSONPeerState(t *testing.T) {
 }
 
 func TestVoteMessageValidateBasic(t *testing.T) {
-	_, vss := randState(2)
+	_, vss := randState(t, 2)
 
 	randBytes := cmtrand.Bytes(tmhash.Size)
 	blockID := types.BlockID{

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -74,6 +74,7 @@ func startNewStateAndWaitForBlock(
 	state, _ := stateStore.LoadFromDBOrGenesisFile(consensusReplayConfig.GenesisFile())
 	privValidator := loadPrivValidator(consensusReplayConfig)
 	cs := newStateWithConfigAndBlockStore(
+		t,
 		consensusReplayConfig,
 		state,
 		privValidator,
@@ -173,6 +174,7 @@ func TestWALCrashOnInternalBlockPartWrite(t *testing.T) {
 
 	privValidator := loadPrivValidator(consensusReplayConfig)
 	cs := newStateWithConfigAndBlockStore(
+		t,
 		consensusReplayConfig,
 		state,
 		privValidator,
@@ -227,6 +229,7 @@ LOOP:
 		require.NoError(t, err)
 		privValidator := loadPrivValidator(consensusReplayConfig)
 		cs := newStateWithConfigAndBlockStore(
+			t,
 			consensusReplayConfig,
 			state,
 			privValidator,

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -34,6 +34,11 @@ import (
 
 var msgQueueSize = 1000
 
+// taskQueueSize bounds the number of pending fireEvents tasks queued for the
+// async runner. Sized to absorb subscriber lag without applying backpressure
+// on the consensus thread.
+const taskQueueSize = 128
+
 // msgs from the reactor which may update the state
 type msgInfo struct {
 	Msg    Message `json:"msg"`
@@ -135,6 +140,10 @@ type State struct {
 
 	// offline state sync height indicating to which height the node synced offline
 	offlineStateSyncHeight int64
+
+	// taskRunnerCancel stops the goroutine spawned by spawnTaskRunner. Called
+	// from OnStop so consensus shutdown does not leak goroutines.
+	taskRunnerCancel context.CancelFunc
 }
 
 // StateOption sets an optional parameter on the State.
@@ -173,6 +182,11 @@ func NewState(
 	cs.decideProposal = cs.defaultDecideProposal
 	cs.doPrevote = cs.defaultDoPrevote
 	cs.setProposal = cs.defaultSetProposal
+
+	// Dispatch fireEvents off the consensus thread.
+	runnerCtx, cancel := context.WithCancel(context.Background())
+	cs.taskRunnerCancel = cancel
+	blockExec.SetTaskRunner(spawnTaskRunner(runnerCtx, taskQueueSize))
 
 	// We have no votes, so reconstruct LastCommit from SeenCommit.
 	if state.LastBlockHeight > 0 {
@@ -435,7 +449,17 @@ func (cs *State) OnStop() {
 	if err := cs.timeoutTicker.Stop(); err != nil {
 		cs.Logger.Error("failed trying to stop timeoutTicket", "error", err)
 	}
+	cs.stopTaskRunner()
 	// WAL is stopped in receiveRoutine.
+}
+
+// stopTaskRunner cancels the task-runner goroutine spawned by NewState. Safe
+// to call multiple times and on an unstarted State; intended for OnStop and
+// for test cleanup paths that bypass Start/Stop.
+func (cs *State) stopTaskRunner() {
+	if cs.taskRunnerCancel != nil {
+		cs.taskRunnerCancel()
+	}
 }
 
 // Wait waits for the main routine to return.
@@ -2706,4 +2730,30 @@ func repairWalFile(src, dst string) error {
 	}
 
 	return nil
+}
+
+// spawnTaskRunner returns a runner that executes submitted closures on a
+// single dedicated goroutine. Tasks are buffered in a channel of the given
+// size; submitters block once the buffer is full, providing natural
+// backpressure if the consumer falls behind. The goroutine and any blocked
+// submitter exit when ctx is canceled; tasks submitted after cancel are
+// dropped.
+func spawnTaskRunner(ctx context.Context, size int) func(func()) {
+	ch := make(chan func(), size)
+	go func() {
+		for {
+			select {
+			case task := <-ch:
+				task()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return func(task func()) {
+		select {
+		case ch <- task:
+		case <-ctx.Done():
+		}
+	}
 }

--- a/consensus/state_ingest_test.go
+++ b/consensus/state_ingest_test.go
@@ -387,7 +387,7 @@ type ingestTestSuite struct {
 }
 
 func newIngestTestSuite(t *testing.T) *ingestTestSuite {
-	cs, validators := randState(4)
+	cs, validators := randState(t, 4)
 
 	return &ingestTestSuite{
 		t:          t,

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -63,7 +63,7 @@ x * TestHalt1 - if we see +2/3 precommits after timing out into new round, we sh
 // ProposeSuite
 
 func TestStateProposerSelection0(t *testing.T) {
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	height, round := cs1.Height, cs1.Round
 
 	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
@@ -102,7 +102,7 @@ func TestStateProposerSelection0(t *testing.T) {
 
 // Now let's do it all again, but starting from round 2 instead of 0
 func TestStateProposerSelection2(t *testing.T) {
-	cs1, vss := randState(4) // test needs more work for more than 3 validators
+	cs1, vss := randState(t, 4) // test needs more work for more than 3 validators
 	height := cs1.Height
 	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
 
@@ -138,7 +138,7 @@ func TestStateProposerSelection2(t *testing.T) {
 
 // a non-validator should timeout into the prevote round
 func TestStateEnterProposeNoPrivValidator(t *testing.T) {
-	cs, _ := randState(1)
+	cs, _ := randState(t, 1)
 	cs.SetPrivValidator(nil)
 	height, round := cs.Height, cs.Round
 
@@ -157,7 +157,7 @@ func TestStateEnterProposeNoPrivValidator(t *testing.T) {
 
 // a validator should not timeout of the prevote round (TODO: unless the block is really big!)
 func TestStateEnterProposeYesPrivValidator(t *testing.T) {
-	cs, _ := randState(1)
+	cs, _ := randState(t, 1)
 	height, round := cs.Height, cs.Round
 
 	// Listen for propose timeout event
@@ -189,7 +189,7 @@ func TestStateEnterProposeYesPrivValidator(t *testing.T) {
 func TestStateBadProposal(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(2)
+	cs1, vss := randState(t, 2)
 	height, round := cs1.Height, cs1.Round
 	vs2 := vss[1]
 
@@ -271,7 +271,7 @@ func TestStateOversizedBlock(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			cs1, vss := randState(2)
+			cs1, vss := randState(t, 2)
 			cs1.state.ConsensusParams.Block.MaxBytes = maxBytes
 			height, round := cs1.Height, cs1.Round
 			vs2 := vss[1]
@@ -356,7 +356,7 @@ func TestStateOversizedBlock(t *testing.T) {
 
 // propose, prevote, and precommit a block
 func TestStateFullRound1(t *testing.T) {
-	cs, vss := randState(1)
+	cs, vss := randState(t, 1)
 	height, round := cs.Height, cs.Round
 
 	// NOTE: buffer capacity of 0 ensures we can validate prevote and last commit
@@ -395,7 +395,7 @@ func TestStateFullRound1(t *testing.T) {
 
 // nil is proposed, so prevote and precommit nil
 func TestStateFullRoundNil(t *testing.T) {
-	cs, _ := randState(1)
+	cs, _ := randState(t, 1)
 	height, round := cs.Height, cs.Round
 
 	voteCh := subscribeUnBuffered(cs.eventBus, types.EventQueryVote)
@@ -410,7 +410,7 @@ func TestStateFullRoundNil(t *testing.T) {
 // run through propose, prevote, precommit commit with two validators
 // where the first validator has to wait for votes from the second
 func TestStateFullRound2(t *testing.T) {
-	cs1, vss := randState(2)
+	cs1, vss := randState(t, 2)
 	vs2 := vss[1]
 	height, round := cs1.Height, cs1.Round
 
@@ -452,7 +452,7 @@ func TestStateFullRound2(t *testing.T) {
 func TestStateLockNoPOL(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(2)
+	cs1, vss := randState(t, 2)
 	vs2 := vss[1]
 	height, round := cs1.Height, cs1.Round
 
@@ -596,7 +596,7 @@ func TestStateLockNoPOL(t *testing.T) {
 
 	ensureNewTimeout(timeoutWaitCh, height, round, cs1.config.Precommit(round).Nanoseconds())
 
-	cs2, _ := randState(2) // needed so generated block is different than locked block
+	cs2, _ := randState(t, 2) // needed so generated block is different than locked block
 	// before we time out into new round, set next proposal block
 	prop, propBlock := decideProposal(ctx, t, cs2, vs2, vs2.Height, vs2.Round+1)
 	if prop == nil || propBlock == nil {
@@ -655,7 +655,7 @@ func TestStateLockNoPOL(t *testing.T) {
 func TestStateLockPOLRelock(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -698,7 +698,7 @@ func TestStateLockPOLRelock(t *testing.T) {
 	signAddVotes(cs1, cmtproto.PrecommitType, nil, types.PartSetHeader{}, true, vs2, vs3, vs4)
 
 	// before we timeout to the new round set the new proposal
-	cs2 := newState(cs1.state, vs2, kvstore.NewInMemoryApplication())
+	cs2 := newState(t, cs1.state, vs2, kvstore.NewInMemoryApplication())
 	prop, propBlock := decideProposal(ctx, t, cs2, vs2, vs2.Height, vs2.Round+1)
 	if prop == nil || propBlock == nil {
 		t.Fatal("Failed to create proposal block with vs2")
@@ -755,7 +755,7 @@ func TestStateLockPOLRelock(t *testing.T) {
 func TestStateLockPOLUnlock(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -849,7 +849,7 @@ func TestStateLockPOLUnlock(t *testing.T) {
 func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -888,7 +888,7 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 	signAddVotes(cs1, cmtproto.PrecommitType, nil, types.PartSetHeader{}, true, vs2, vs3, vs4)
 
 	// before we timeout to the new round set the new proposal
-	cs2 := newState(cs1.state, vs2, kvstore.NewInMemoryApplication())
+	cs2 := newState(t, cs1.state, vs2, kvstore.NewInMemoryApplication())
 	prop, propBlock := decideProposal(ctx, t, cs2, vs2, vs2.Height, vs2.Round+1)
 	if prop == nil || propBlock == nil {
 		t.Fatal("Failed to create proposal block with vs2")
@@ -934,7 +934,7 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 	signAddVotes(cs1, cmtproto.PrecommitType, nil, types.PartSetHeader{}, true, vs2, vs3, vs4)
 
 	// before we timeout to the new round set the new proposal
-	cs3 := newState(cs1.state, vs3, kvstore.NewInMemoryApplication())
+	cs3 := newState(t, cs1.state, vs3, kvstore.NewInMemoryApplication())
 	prop, propBlock = decideProposal(ctx, t, cs3, vs3, vs3.Height, vs3.Round+1)
 	if prop == nil || propBlock == nil {
 		t.Fatal("Failed to create proposal block with vs2")
@@ -979,7 +979,7 @@ func TestStateLockPOLUnlockOnUnknownBlock(t *testing.T) {
 func TestStateLockPOLSafety1(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1104,7 +1104,7 @@ func TestStateLockPOLSafety1(t *testing.T) {
 func TestStateLockPOLSafety2(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1202,7 +1202,7 @@ func TestStateLockPOLSafety2(t *testing.T) {
 // What we want:
 // P0 proposes B0 at R3.
 func TestProposeValidBlock(t *testing.T) {
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1294,7 +1294,7 @@ func TestProposeValidBlock(t *testing.T) {
 // What we want:
 // P0 miss to lock B but set valid block to B after receiving delayed prevote.
 func TestSetValidBlockOnDelayedPrevote(t *testing.T) {
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1359,7 +1359,7 @@ func TestSetValidBlockOnDelayedPrevote(t *testing.T) {
 func TestSetValidBlockOnDelayedProposal(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1437,7 +1437,7 @@ func TestProcessProposalAccept(t *testing.T) {
 			}
 			m.On("ProcessProposal", mock.Anything, mock.Anything).Return(&abci.ResponseProcessProposal{Status: status}, nil)
 			m.On("PrepareProposal", mock.Anything, mock.Anything).Return(&abci.ResponsePrepareProposal{}, nil).Maybe()
-			cs1, _ := randStateWithApp(4, m)
+			cs1, _ := randStateWithApp(t, 4, m)
 			height, round := cs1.Height, cs1.Round
 
 			proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)
@@ -1494,7 +1494,7 @@ func TestExtendVoteCalledWhenEnabled(t *testing.T) {
 			if !testCase.enabled {
 				height = 0
 			}
-			cs1, vss := randStateWithAppWithHeight(4, m, height)
+			cs1, vss := randStateWithAppWithHeight(t, 4, m, height)
 
 			height, round := cs1.Height, cs1.Round
 
@@ -1576,7 +1576,7 @@ func TestVerifyVoteExtensionNotCalledOnAbsentPrecommit(t *testing.T) {
 	}, nil)
 	m.On("FinalizeBlock", mock.Anything, mock.Anything).Return(&abci.ResponseFinalizeBlock{}, nil).Maybe()
 	m.On("Commit", mock.Anything, mock.Anything).Return(&abci.ResponseCommit{}, nil).Maybe()
-	cs1, vss := randStateWithApp(4, m)
+	cs1, vss := randStateWithApp(t, 4, m)
 	height, round := cs1.Height, cs1.Round
 	cs1.state.ConsensusParams.ABCI.VoteExtensionsEnableHeight = cs1.Height
 
@@ -1663,7 +1663,7 @@ func TestPrepareProposalReceivesVoteExtensions(t *testing.T) {
 	m.On("Commit", mock.Anything, mock.Anything).Return(&abci.ResponseCommit{}, nil).Maybe()
 	m.On("FinalizeBlock", mock.Anything, mock.Anything).Return(&abci.ResponseFinalizeBlock{}, nil)
 
-	cs1, vss := randStateWithApp(4, m)
+	cs1, vss := randStateWithApp(t, 4, m)
 	height, round := cs1.Height, cs1.Round
 
 	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
@@ -1763,7 +1763,7 @@ func TestFinalizeBlockCalled(t *testing.T) {
 			m.On("FinalizeBlock", mock.Anything, mock.Anything).Return(r, nil).Maybe()
 			m.On("Commit", mock.Anything, mock.Anything).Return(&abci.ResponseCommit{}, nil).Maybe()
 
-			cs1, vss := randStateWithApp(4, m)
+			cs1, vss := randStateWithApp(t, 4, m)
 			height, round := cs1.Height, cs1.Round
 
 			proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)
@@ -1877,7 +1877,7 @@ func TestVoteExtensionEnableHeight(t *testing.T) {
 			}
 			m.On("FinalizeBlock", mock.Anything, mock.Anything).Return(&abci.ResponseFinalizeBlock{}, nil).Maybe()
 			m.On("Commit", mock.Anything, mock.Anything).Return(&abci.ResponseCommit{}, nil).Maybe()
-			cs1, vss := randStateWithAppWithHeight(numValidators, m, testCase.enableHeight)
+			cs1, vss := randStateWithAppWithHeight(t, numValidators, m, testCase.enableHeight)
 			cs1.state.ConsensusParams.ABCI.VoteExtensionsEnableHeight = testCase.enableHeight
 			height, round := cs1.Height, cs1.Round
 
@@ -1924,7 +1924,7 @@ func TestVoteExtensionEnableHeight(t *testing.T) {
 // receiving an invalid vote. In particular, one with the incorrect
 // ValidatorIndex.
 func TestStateDoesntCrashOnInvalidVote(t *testing.T) {
-	cs, vss := randState(2)
+	cs, vss := randState(t, 2)
 	height, round := cs.Height, cs.Round
 	// create dummy peer
 	peer := p2pmock.NewPeer(nil)
@@ -1955,8 +1955,8 @@ func TestStateDoesntCrashOnInvalidVote(t *testing.T) {
 // 4 vals, 3 Nil Precommits at P0
 // What we want:
 // P0 waits for timeoutPrecommit before starting next round
-func TestWaitingTimeoutOnNilPolka(*testing.T) {
-	cs1, vss := randState(4)
+func TestWaitingTimeoutOnNilPolka(t *testing.T) {
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -1977,7 +1977,7 @@ func TestWaitingTimeoutOnNilPolka(*testing.T) {
 // What we want:
 // P0 waits for timeoutPropose in the next round before entering prevote
 func TestWaitingTimeoutProposeOnNewRound(t *testing.T) {
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -2013,7 +2013,7 @@ func TestWaitingTimeoutProposeOnNewRound(t *testing.T) {
 // What we want:
 // P0 jump to higher round, precommit and start precommit wait
 func TestRoundSkipOnNilPolkaFromHigherRound(t *testing.T) {
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 
@@ -2049,7 +2049,7 @@ func TestRoundSkipOnNilPolkaFromHigherRound(t *testing.T) {
 // What we want:
 // P0 wait for timeoutPropose to expire before sending prevote.
 func TestWaitTimeoutProposeOnNilPolkaForTheCurrentRound(t *testing.T) {
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, int32(1)
 
@@ -2078,7 +2078,7 @@ func TestWaitTimeoutProposeOnNilPolkaForTheCurrentRound(t *testing.T) {
 func TestEmitNewValidBlockEventOnCommitWithoutBlock(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, int32(1)
 
@@ -2114,7 +2114,7 @@ func TestEmitNewValidBlockEventOnCommitWithoutBlock(t *testing.T) {
 func TestCommitFromPreviousRound(t *testing.T) {
 	ctx := t.Context()
 
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, int32(1)
 
@@ -2169,7 +2169,7 @@ func (n *fakeTxNotifier) Notify() {
 // start of the next round
 func TestStartNextHeightCorrectlyAfterTimeout(t *testing.T) {
 	config.Consensus.SkipTimeoutCommit = false
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	cs1.txNotifier = &fakeTxNotifier{ch: make(chan struct{})}
 
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
@@ -2231,7 +2231,7 @@ func TestResetTimeoutPrecommitUponNewHeight(t *testing.T) {
 	ctx := t.Context()
 
 	config.Consensus.SkipTimeoutCommit = false
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
@@ -2292,7 +2292,7 @@ func TestResetTimeoutPrecommitUponNewHeight(t *testing.T) {
 
 /*
 func TestStateSlashingPrevotes(t *testing.T) {
-	cs1, vss := randState(2)
+	cs1, vss := randState(t, 2)
 	vs2 := vss[1]
 
 
@@ -2327,7 +2327,7 @@ func TestStateSlashingPrevotes(t *testing.T) {
 }
 
 func TestStateSlashingPrecommits(t *testing.T) {
-	cs1, vss := randState(2)
+	cs1, vss := randState(t, 2)
 	vs2 := vss[1]
 
 
@@ -2372,7 +2372,7 @@ func TestStateSlashingPrecommits(t *testing.T) {
 // 4 vals.
 // we receive a final precommit after going into next round, but others might have gone to commit already!
 func TestStateHalt1(t *testing.T) {
-	cs1, vss := randState(4)
+	cs1, vss := randState(t, 4)
 	vs2, vs3, vs4 := vss[1], vss[2], vss[3]
 	height, round := cs1.Height, cs1.Round
 	partSize := types.BlockPartSizeBytes
@@ -2441,7 +2441,7 @@ func TestStateHalt1(t *testing.T) {
 
 func TestStateOutputsBlockPartsStats(t *testing.T) {
 	// create dummy peer
-	cs, _ := randState(1)
+	cs, _ := randState(t, 1)
 	peer := p2pmock.NewPeer(nil)
 
 	// 1) new block part
@@ -2482,7 +2482,7 @@ func TestStateOutputsBlockPartsStats(t *testing.T) {
 }
 
 func TestProposalBlockPartsHeightConsistency(t *testing.T) {
-	cs, _ := randState(1)
+	cs, _ := randState(t, 1)
 
 	block, err := cs.state.MakeBlock(
 		cs.Height+1,
@@ -2516,7 +2516,7 @@ func TestProposalBlockPartsHeightConsistency(t *testing.T) {
 }
 
 func TestStateOutputVoteStats(t *testing.T) {
-	cs, vss := randState(2)
+	cs, vss := randState(t, 2)
 	// create dummy peer
 	peer := p2pmock.NewPeer(nil)
 
@@ -2548,7 +2548,7 @@ func TestStateOutputVoteStats(t *testing.T) {
 }
 
 func TestSignSameVoteTwice(t *testing.T) {
-	_, vss := randState(2)
+	_, vss := randState(t, 2)
 
 	randBytes := cmtrand.Bytes(tmhash.Size)
 
@@ -2683,4 +2683,67 @@ func TestWALSelectiveFsyncUnexpectedTypePanics(t *testing.T) {
 	require.Panics(t, func() {
 		cs.writeInternalMsgToWAL(unknown)
 	})
+}
+
+// TestSpawnTaskRunnerExecutesInOrder verifies that spawnTaskRunner runs
+// submitted closures sequentially on a single goroutine and preserves
+// submission order.
+func TestSpawnTaskRunnerExecutesInOrder(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	run := spawnTaskRunner(ctx, 8)
+
+	const n = 16
+	results := make(chan int, n)
+	for i := 0; i < n; i++ {
+		run(func() { results <- i })
+	}
+
+	for i := 0; i < n; i++ {
+		select {
+		case got := <-results:
+			require.Equal(t, i, got, "tasks must execute in submission order")
+		case <-time.After(time.Second):
+			t.Fatalf("task %d did not run", i)
+		}
+	}
+}
+
+// TestSpawnTaskRunnerBackpressure verifies that submissions block once the
+// internal buffer fills, providing natural backpressure rather than dropping
+// tasks.
+func TestSpawnTaskRunnerBackpressure(t *testing.T) {
+	const buf = 2
+	block := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	run := spawnTaskRunner(ctx, buf)
+
+	// First task occupies the worker and blocks indefinitely until released.
+	run(func() { <-block })
+	// Fill the buffer.
+	for i := 0; i < buf; i++ {
+		run(func() {})
+	}
+
+	// Next submission must block: worker is busy, buffer is full.
+	submitted := make(chan struct{})
+	go func() {
+		run(func() {})
+		close(submitted)
+	}()
+
+	select {
+	case <-submitted:
+		t.Fatal("submission did not block when buffer was full")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Releasing the worker drains the buffer and unblocks the submitter.
+	close(block)
+	select {
+	case <-submitted:
+	case <-time.After(time.Second):
+		t.Fatal("submission did not unblock after worker drained")
+	}
 }

--- a/state/execution.go
+++ b/state/execution.go
@@ -50,6 +50,10 @@ type BlockExecutor struct {
 
 	// blockTimeTolerance is the maximum allowed difference between proposed block time and wall clock.
 	blockTimeTolerance time.Duration
+
+	// asyncRunner, if set, dispatches non-critical post-commit work
+	// (e.g. fireEvents) off the consensus thread.
+	asyncRunner func(func())
 }
 
 type BlockExecutorOption func(executor *BlockExecutor)
@@ -103,6 +107,13 @@ func (blockExec *BlockExecutor) Store() Store {
 // If not called, it defaults to types.NopEventBus.
 func (blockExec *BlockExecutor) SetEventBus(eventBus types.BlockEventPublisher) {
 	blockExec.eventBus = eventBus
+}
+
+// SetTaskRunner installs a runner that executes non-critical post-commit
+// work (currently fireEvents) off the consensus thread. Must be called
+// before Start; passing nil reverts to synchronous execution.
+func (blockExec *BlockExecutor) SetTaskRunner(runner func(func())) {
+	blockExec.asyncRunner = runner
 }
 
 // CreateProposalBlock calls state.MakeBlock with evidence from the evpool
@@ -374,7 +385,14 @@ func (blockExec *BlockExecutor) applyBlock(state State, blockID types.BlockID, b
 
 	// Events are fired after everything else.
 	// NOTE: if we crash between Commit and Save, events wont be fired during replay
-	fireEvents(blockExec.logger, blockExec.eventBus, block, blockID, abciResponse, validatorUpdates)
+	fire := func() {
+		fireEvents(blockExec.logger, blockExec.eventBus, block, blockID, abciResponse, validatorUpdates)
+	}
+	if blockExec.asyncRunner != nil {
+		blockExec.asyncRunner(fire)
+	} else {
+		fire()
+	}
 
 	return state, nil
 }

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -80,6 +80,96 @@ func TestApplyBlock(t *testing.T) {
 	assert.EqualValues(t, 1, state.Version.Consensus.App, "App version wasn't updated")
 }
 
+// TestApplyBlockAsyncRunner verifies that when SetTaskRunner is configured,
+// fireEvents is dispatched via the runner (off the consensus thread) rather
+// than executed synchronously inside ApplyBlock.
+func TestApplyBlockAsyncRunner(t *testing.T) {
+	app := &testApp{}
+	cc := proxy.NewLocalClientCreator(app)
+	proxyApp := proxy.NewAppConns(cc, proxy.NopMetrics())
+	err := proxyApp.Start()
+	require.NoError(t, err)
+	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
+
+	state, stateDB, _ := makeState(1, 1)
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+	blockStore := store.NewBlockStore(dbm.NewMemDB())
+
+	mp := &mpmocks.Mempool{}
+	mp.On("Lock").Return()
+	mp.On("Unlock").Return()
+	mp.On("FlushAppConn", mock.Anything).Return(nil)
+	mp.On("Update",
+		mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),
+		mp, sm.EmptyEvidencePool{}, blockStore)
+
+	eventBus := types.NewEventBus()
+	require.NoError(t, eventBus.Start())
+	defer eventBus.Stop() //nolint:errcheck // ignore for tests
+	blockExec.SetEventBus(eventBus)
+
+	// Subscribe to validator-set updates so we can observe whether fireEvents
+	// has run yet.
+	updatesSub, err := eventBus.Subscribe(
+		context.Background(),
+		"TestApplyBlockAsyncRunner",
+		types.EventQueryValidatorSetUpdates,
+	)
+	require.NoError(t, err)
+
+	// Force a validator update so fireEvents emits an event we can observe.
+	pubkey := ed25519.GenPrivKey().PubKey()
+	pk, err := cryptoenc.PubKeyToProto(pubkey)
+	require.NoError(t, err)
+	app.ValidatorUpdates = []abci.ValidatorUpdate{{PubKey: pk, Power: 10}}
+
+	// Capture submitted closures instead of running them. ApplyBlock must not
+	// block waiting for the closure to execute.
+	tasks := make(chan func(), 1)
+	blockExec.SetTaskRunner(func(task func()) {
+		tasks <- task
+	})
+
+	block, err := makeBlock(state, 1, new(types.Commit))
+	require.NoError(t, err)
+	bps, err := block.MakePartSet(testPartSize)
+	require.NoError(t, err)
+	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
+
+	_, err = blockExec.ApplyBlock(state, blockID, block)
+	require.NoError(t, err)
+
+	// fireEvents should have been deferred to the runner — no event yet.
+	select {
+	case <-updatesSub.Out():
+		t.Fatal("fireEvents ran synchronously; expected dispatch via task runner")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Drain and run the deferred closure.
+	var task func()
+	select {
+	case task = <-tasks:
+	case <-time.After(time.Second):
+		t.Fatal("task runner was not invoked")
+	}
+	task()
+
+	// Now the event must arrive.
+	select {
+	case <-updatesSub.Out():
+	case <-updatesSub.Canceled():
+		t.Fatalf("updatesSub canceled: %v", updatesSub.Err())
+	case <-time.After(time.Second):
+		t.Fatal("did not receive EventValidatorSetUpdates after running task")
+	}
+}
+
 // TestFinalizeBlockDecidedLastCommit ensures we correctly send the
 // DecidedLastCommit to the application. The test ensures that the
 // DecidedLastCommit properly reflects which validators signed the preceding


### PR DESCRIPTION
## Summary

backport https://github.com/crypto-org-chain/cometbft/pull/6
- Move post-commit `fireEvents` off the consensus thread via a single-goroutine, 128-buffered task runner.
- Wire it through `BlockExecutor.SetTaskRunner`; consensus `NewState` spawns and `OnStop` cancels.
- Test helpers register `t.Cleanup` so paths bypassing Start/Stop don't leak the goroutine.

## Notes

- Stacks on top of #44 (sync upstream). Apply after #44 merges.
