### PR TITLE
perf(abci): add lock-free local client + per-conn ClientCreator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 - `[consensus]` perf(consensus): dispatch fireEvents off the consensus thread via a buffered task runner
   ([\#45](https://github.com/crypto-org-chain/cometbft/pull/45))
+- `[abci]` perf(abci): add lock-free `unsyncLocalClient` and split `ClientCreator` into per-conn methods
+  ([\#46](https://github.com/crypto-org-chain/cometbft/pull/46))
 - `[blocksync]` validate blocksync response sender and signature count
   ([\#5860](https://github.com/cometbft/cometbft/pull/5860))
 

--- a/abci/client/unsync_local_client.go
+++ b/abci/client/unsync_local_client.go
@@ -1,0 +1,70 @@
+package abcicli
+
+import (
+	"context"
+	"sync/atomic"
+
+	types "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/libs/service"
+)
+
+// unsyncLocalClient is a variant of localClient that does NOT acquire an
+// application-wide mutex around ABCI calls. The wrapped Application must be
+// safe for concurrent use; callers (e.g. cosmos-sdk + ethermint) are
+// responsible for their own concurrency control.
+//
+// The response Callback is stored behind atomic.Pointer for lock-free reads
+// on every CheckTxAsync. App invocations (CheckTx, Query, Commit,
+// FinalizeBlock, ...) reach the wrapped Application directly via embedding
+// promotion, with no lock.
+type unsyncLocalClient struct {
+	service.BaseService
+
+	types.Application
+	cb atomic.Pointer[Callback]
+}
+
+var _ Client = (*unsyncLocalClient)(nil)
+
+// NewUnsyncLocalClient creates a local client that does not synchronize ABCI
+// calls behind a global mutex. The wrapped Application is expected to be
+// concurrency-safe.
+func NewUnsyncLocalClient(app types.Application) Client {
+	cli := &unsyncLocalClient{
+		Application: app,
+	}
+	cli.BaseService = *service.NewBaseService(nil, "unsyncLocalClient", cli)
+	return cli
+}
+
+func (app *unsyncLocalClient) SetResponseCallback(cb Callback) {
+	app.cb.Store(&cb)
+}
+
+func (app *unsyncLocalClient) CheckTxAsync(ctx context.Context, req *types.RequestCheckTx) (*ReqRes, error) {
+	res, err := app.Application.CheckTx(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return app.callback(
+		types.ToRequestCheckTx(req),
+		types.ToResponseCheckTx(res),
+	), nil
+}
+
+func (app *unsyncLocalClient) callback(req *types.Request, res *types.Response) *ReqRes {
+	(*app.cb.Load())(req, res)
+	rr := newLocalReqRes(req, res)
+	rr.callbackInvoked = true
+	return rr
+}
+
+// Client interface methods not provided by types.Application.
+
+func (app *unsyncLocalClient) Error() error { return nil }
+
+func (app *unsyncLocalClient) Flush(context.Context) error { return nil }
+
+func (app *unsyncLocalClient) Echo(_ context.Context, msg string) (*types.ResponseEcho, error) {
+	return &types.ResponseEcho{Message: msg}, nil
+}

--- a/abci/client/unsync_local_client.go
+++ b/abci/client/unsync_local_client.go
@@ -42,7 +42,7 @@ func (app *unsyncLocalClient) SetResponseCallback(cb Callback) {
 }
 
 func (app *unsyncLocalClient) CheckTxAsync(ctx context.Context, req *types.RequestCheckTx) (*ReqRes, error) {
-	res, err := app.Application.CheckTx(ctx, req)
+	res, err := app.CheckTx(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/abci/client/unsync_local_client_test.go
+++ b/abci/client/unsync_local_client_test.go
@@ -1,0 +1,108 @@
+package abcicli_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	abcicli "github.com/cometbft/cometbft/abci/client"
+	"github.com/cometbft/cometbft/abci/types"
+)
+
+// concurrentApp counts how many CheckTx calls observe a peer mid-flight.
+// If the unsyncLocalClient is correctly lock-free, observed > 0 under
+// concurrent load; if a global mutex is silently reintroduced, observed == 0
+// because calls would serialize.
+type concurrentApp struct {
+	types.BaseApplication
+
+	inFlight int32
+	maxSeen  int32
+}
+
+func (a *concurrentApp) CheckTx(_ context.Context, _ *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+	cur := atomic.AddInt32(&a.inFlight, 1)
+	defer atomic.AddInt32(&a.inFlight, -1)
+	for {
+		prev := atomic.LoadInt32(&a.maxSeen)
+		if cur <= prev || atomic.CompareAndSwapInt32(&a.maxSeen, prev, cur) {
+			break
+		}
+	}
+	return &types.ResponseCheckTx{Code: types.CodeTypeOK}, nil
+}
+
+func TestUnsyncLocalClient_ConcurrentCheckTxObservesParallelism(t *testing.T) {
+	app := &concurrentApp{}
+	cli := abcicli.NewUnsyncLocalClient(app)
+	require.NoError(t, cli.Start())
+	t.Cleanup(func() { _ = cli.Stop() })
+
+	cli.SetResponseCallback(func(*types.Request, *types.Response) {})
+
+	const goroutines = 32
+	const perGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				_, err := cli.CheckTxAsync(context.Background(), &types.RequestCheckTx{Tx: []byte("tx")})
+				require.NoError(t, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Lock-free client must let multiple CheckTx calls overlap.
+	require.Greater(t, atomic.LoadInt32(&app.maxSeen), int32(1),
+		"expected concurrent CheckTx calls to overlap; observed serialization (maxSeen=%d)", app.maxSeen)
+}
+
+func TestUnsyncLocalClient_CheckTxInvokesCallback(t *testing.T) {
+	app := types.BaseApplication{}
+	cli := abcicli.NewUnsyncLocalClient(app)
+	require.NoError(t, cli.Start())
+	t.Cleanup(func() { _ = cli.Stop() })
+
+	var got atomic.Int32
+	cli.SetResponseCallback(func(_ *types.Request, _ *types.Response) {
+		got.Add(1)
+	})
+
+	_, err := cli.CheckTxAsync(context.Background(), &types.RequestCheckTx{Tx: []byte("tx")})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), got.Load())
+}
+
+func TestUnsyncLocalClient_SetResponseCallbackRaceFree(t *testing.T) {
+	app := types.BaseApplication{}
+	cli := abcicli.NewUnsyncLocalClient(app)
+	require.NoError(t, cli.Start())
+	t.Cleanup(func() { _ = cli.Stop() })
+
+	cb := func(*types.Request, *types.Response) {}
+	cli.SetResponseCallback(cb)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			cli.SetResponseCallback(cb)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_, err := cli.CheckTxAsync(context.Background(), &types.RequestCheckTx{Tx: []byte("tx")})
+			require.NoError(t, err)
+		}
+	}()
+	wg.Wait()
+}

--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -61,7 +61,7 @@ func newMockProxyApp(finalizeBlockResponse *abci.ResponseFinalizeBlock) proxy.Ap
 	clientCreator := proxy.NewLocalClientCreator(&mockProxyApp{
 		finalizeBlockResponse: finalizeBlockResponse,
 	})
-	cli, _ := clientCreator.NewABCIClient()
+	cli, _ := clientCreator.NewABCIConsensusClient()
 	err := cli.Start()
 	if err != nil {
 		panic(err)

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -67,7 +67,7 @@ func newMempoolWithApp(cc proxy.ClientCreator) (*CListMempool, cleanupFunc) {
 }
 
 func newMempoolWithAppAndConfig(cc proxy.ClientCreator, cfg *config.Config) (*CListMempool, cleanupFunc) {
-	client, _ := cc.NewABCIClient()
+	client, _ := cc.NewABCIMempoolClient()
 	client.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "mempool"))
 	err := client.Start()
 	if err != nil {
@@ -427,7 +427,7 @@ func TestSerialReap(t *testing.T) {
 	mp, cleanup := newMempoolWithApp(cc)
 	defer cleanup()
 
-	appConnCon, _ := cc.NewABCIClient()
+	appConnCon, _ := cc.NewABCIConsensusClient()
 	appConnCon.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "consensus"))
 	err := appConnCon.Start()
 	require.Nil(t, err)
@@ -632,7 +632,7 @@ func TestMempoolTxsBytes(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, 10, mp.SizeBytes())
 
-	appConnCon, _ := cc.NewABCIClient()
+	appConnCon, _ := cc.NewABCIConsensusClient()
 	appConnCon.SetLogger(log.TestingLogger().With("module", "abci-client", "connection", "consensus"))
 	err = appConnCon.Start()
 	require.Nil(t, err)

--- a/proxy/app_conn_test.go
+++ b/proxy/app_conn_test.go
@@ -31,7 +31,7 @@ func TestEcho(t *testing.T) {
 	})
 
 	// Start client
-	cli, err := clientCreator.NewABCIClient()
+	cli, err := clientCreator.NewABCIMempoolClient()
 	if err != nil {
 		t.Fatalf("Error creating ABCI client: %v", err.Error())
 	}
@@ -72,7 +72,7 @@ func BenchmarkEcho(b *testing.B) {
 	})
 
 	// Start client
-	cli, err := clientCreator.NewABCIClient()
+	cli, err := clientCreator.NewABCIMempoolClient()
 	if err != nil {
 		b.Fatalf("Error creating ABCI client: %v", err.Error())
 	}

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -12,90 +12,146 @@ import (
 
 //go:generate ../scripts/mockery_generate.sh ClientCreator
 
-// ClientCreator creates new ABCI clients.
+// ClientCreator creates new ABCI clients, one per CometBFT-to-application
+// connection type (consensus, mempool, query, snapshot). Splitting client
+// construction by connection type lets a creator hand back per-conn clients
+// with different concurrency models — e.g. a locking client for the
+// consensus connection alongside lock-free clients for mempool/query/snapshot.
 type ClientCreator interface {
-	// NewABCIClient returns a new ABCI client.
-	NewABCIClient() (abcicli.Client, error)
+	// NewABCIConsensusClient returns the ABCI client used for the consensus
+	// connection (Commit, FinalizeBlock, ...).
+	NewABCIConsensusClient() (abcicli.Client, error)
+	// NewABCIMempoolClient returns the ABCI client used for the mempool
+	// connection (CheckTx, ...).
+	NewABCIMempoolClient() (abcicli.Client, error)
+	// NewABCIQueryClient returns the ABCI client used for the query
+	// connection (Query, Info, ...).
+	NewABCIQueryClient() (abcicli.Client, error)
+	// NewABCISnapshotClient returns the ABCI client used for the state-sync
+	// snapshot connection.
+	NewABCISnapshotClient() (abcicli.Client, error)
+}
+
+// uniformClientCreator implements ClientCreator by routing every per-conn
+// method to a single factory function. Embed it (and assign make in the
+// constructor) when all four connections should produce identical clients.
+type uniformClientCreator struct {
+	make func() (abcicli.Client, error)
+}
+
+func (u *uniformClientCreator) NewABCIConsensusClient() (abcicli.Client, error) {
+	return u.make()
+}
+func (u *uniformClientCreator) NewABCIMempoolClient() (abcicli.Client, error) {
+	return u.make()
+}
+func (u *uniformClientCreator) NewABCIQueryClient() (abcicli.Client, error) {
+	return u.make()
+}
+func (u *uniformClientCreator) NewABCISnapshotClient() (abcicli.Client, error) {
+	return u.make()
 }
 
 //----------------------------------------------------
-// local proxy uses a mutex on an in-proc app
-
-type localClientCreator struct {
-	mtx *cmtsync.Mutex
-	app types.Application
-}
+// local proxy uses a single mutex on an in-proc app
 
 // NewLocalClientCreator returns a [ClientCreator] for the given app, which
 // will be running locally.
 //
-// Maintains a single mutex over all new clients created with NewABCIClient. For
-// a local client creator that uses a single mutex per new client, rather use
+// All four per-conn clients share a single mutex, serializing every ABCI call
+// across connections. For per-connection mutexes, see
 // [NewConnSyncLocalClientCreator].
 func NewLocalClientCreator(app types.Application) ClientCreator {
-	return &localClientCreator{
-		mtx: new(cmtsync.Mutex),
-		app: app,
+	mtx := new(cmtsync.Mutex)
+	return &uniformClientCreator{
+		make: func() (abcicli.Client, error) {
+			return abcicli.NewLocalClient(mtx, app), nil
+		},
 	}
-}
-
-func (l *localClientCreator) NewABCIClient() (abcicli.Client, error) {
-	return abcicli.NewLocalClient(l.mtx, l.app), nil
 }
 
 //----------------------------------------------------
 // local proxy creates a new mutex for each client
 
-type connSyncLocalClientCreator struct {
-	app types.Application
-}
-
 // NewConnSyncLocalClientCreator returns a local [ClientCreator] for the given
 // app.
 //
 // Unlike [NewLocalClientCreator], this is a "connection-synchronized" local
-// client creator, meaning each call to NewABCIClient returns an ABCI client
-// that maintains its own mutex over the application (i.e. it is
-// per-"connection" synchronized).
+// client creator: each per-conn client maintains its own mutex over the
+// application, so calls on one connection do not block calls on another.
 func NewConnSyncLocalClientCreator(app types.Application) ClientCreator {
-	return &connSyncLocalClientCreator{
-		app: app,
+	return &uniformClientCreator{
+		make: func() (abcicli.Client, error) {
+			// nil mtx => each instance creates its own.
+			return abcicli.NewLocalClient(nil, app), nil
+		},
 	}
 }
 
-func (c *connSyncLocalClientCreator) NewABCIClient() (abcicli.Client, error) {
-	// Specifying nil for the mutex causes each instance to create its own
-	// mutex.
-	return abcicli.NewLocalClient(nil, c.app), nil
+//----------------------------------------------------
+// fully unsynced local creator
+
+// NewUnsyncLocalClientCreator returns a local [ClientCreator] that uses
+// [abcicli.NewUnsyncLocalClient] for all four connections. The application
+// must be fully concurrency-safe; no mutex is held on any ABCI call.
+func NewUnsyncLocalClientCreator(app types.Application) ClientCreator {
+	return &uniformClientCreator{
+		make: func() (abcicli.Client, error) {
+			return abcicli.NewUnsyncLocalClient(app), nil
+		},
+	}
+}
+
+//----------------------------------------------------
+// consensus-sync local creator: locking on consensus, lock-free elsewhere
+
+// consensusSyncLocalClientCreator embeds uniformClientCreator for
+// mempool/query/snapshot and overrides NewABCIConsensusClient with a
+// dedicated factory for the consensus conn.
+type consensusSyncLocalClientCreator struct {
+	uniformClientCreator // mempool / query / snapshot
+	makeConsensus        func() (abcicli.Client, error)
+}
+
+func (c *consensusSyncLocalClientCreator) NewABCIConsensusClient() (abcicli.Client, error) {
+	return c.makeConsensus()
+}
+
+// NewConsensusSyncLocalClientCreator returns a local [ClientCreator] that
+// gives the consensus connection a locking [abcicli.NewLocalClient] (with its
+// own mutex) and gives mempool/query/snapshot connections a lock-free
+// [abcicli.NewUnsyncLocalClient]. The application must be safe for concurrent
+// use across the lock-free connections.
+func NewConsensusSyncLocalClientCreator(app types.Application) ClientCreator {
+	mtx := new(cmtsync.Mutex)
+	return &consensusSyncLocalClientCreator{
+		uniformClientCreator: uniformClientCreator{
+			make: func() (abcicli.Client, error) {
+				return abcicli.NewUnsyncLocalClient(app), nil
+			},
+		},
+		makeConsensus: func() (abcicli.Client, error) {
+			return abcicli.NewLocalClient(mtx, app), nil
+		},
+	}
 }
 
 //---------------------------------------------------------------
 // remote proxy opens new connections to an external app process
 
-type remoteClientCreator struct {
-	addr        string
-	transport   string
-	mustConnect bool
-}
-
 // NewRemoteClientCreator returns a ClientCreator for the given address (e.g.
 // "192.168.0.1") and transport (e.g. "tcp"). Set mustConnect to true if you
 // want the client to connect before reporting success.
 func NewRemoteClientCreator(addr, transport string, mustConnect bool) ClientCreator {
-	return &remoteClientCreator{
-		addr:        addr,
-		transport:   transport,
-		mustConnect: mustConnect,
+	return &uniformClientCreator{
+		make: func() (abcicli.Client, error) {
+			remoteApp, err := abcicli.NewClient(addr, transport, mustConnect)
+			if err != nil {
+				return nil, fmt.Errorf("failed to connect to proxy: %w", err)
+			}
+			return remoteApp, nil
+		},
 	}
-}
-
-func (r *remoteClientCreator) NewABCIClient() (abcicli.Client, error) {
-	remoteApp, err := abcicli.NewClient(r.addr, r.transport, r.mustConnect)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to proxy: %w", err)
-	}
-
-	return remoteApp, nil
 }
 
 // DefaultClientCreator returns a default [ClientCreator], which will create a

--- a/proxy/client_test.go
+++ b/proxy/client_test.go
@@ -1,0 +1,67 @@
+package proxy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/abci/types"
+)
+
+// TestNewConsensusSyncLocalClientCreator_ConnTypeSplit asserts that the
+// creator hands a locking client to the consensus connection and lock-free
+// clients to mempool / query / snapshot.
+//
+// The contract is structural — an unsynced mempool client is the whole point
+// of Patch 3. If the consensus connection ever stops getting a locking
+// client (or vice versa), this test fails.
+func TestNewConsensusSyncLocalClientCreator_ConnTypeSplit(t *testing.T) {
+	app := types.NewBaseApplication()
+	cc := NewConsensusSyncLocalClientCreator(app)
+
+	consensus, err := cc.NewABCIConsensusClient()
+	require.NoError(t, err)
+	require.Contains(t, fmt.Sprintf("%T", consensus), "localClient",
+		"consensus conn must use the locking localClient (got %T)", consensus)
+	require.NotContains(t, fmt.Sprintf("%T", consensus), "unsync",
+		"consensus conn must NOT use unsyncLocalClient (got %T)", consensus)
+
+	for _, tc := range []struct {
+		name string
+		make func() (any, error)
+	}{
+		{"mempool", func() (any, error) { return cc.NewABCIMempoolClient() }},
+		{"query", func() (any, error) { return cc.NewABCIQueryClient() }},
+		{"snapshot", func() (any, error) { return cc.NewABCISnapshotClient() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cli, err := tc.make()
+			require.NoError(t, err)
+			require.Contains(t, fmt.Sprintf("%T", cli), "unsyncLocalClient",
+				"%s conn must use unsyncLocalClient (got %T)", tc.name, cli)
+		})
+	}
+}
+
+func TestNewUnsyncLocalClientCreator_AllUnsync(t *testing.T) {
+	app := types.NewBaseApplication()
+	cc := NewUnsyncLocalClientCreator(app)
+
+	for _, tc := range []struct {
+		name string
+		make func() (any, error)
+	}{
+		{"consensus", func() (any, error) { return cc.NewABCIConsensusClient() }},
+		{"mempool", func() (any, error) { return cc.NewABCIMempoolClient() }},
+		{"query", func() (any, error) { return cc.NewABCIQueryClient() }},
+		{"snapshot", func() (any, error) { return cc.NewABCISnapshotClient() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cli, err := tc.make()
+			require.NoError(t, err)
+			require.Contains(t, fmt.Sprintf("%T", cli), "unsyncLocalClient",
+				"%s conn must use unsyncLocalClient (got %T)", tc.name, cli)
+		})
+	}
+}

--- a/proxy/mocks/client_creator.go
+++ b/proxy/mocks/client_creator.go
@@ -12,12 +12,102 @@ type ClientCreator struct {
 	mock.Mock
 }
 
-// NewABCIClient provides a mock function with no fields
-func (_m *ClientCreator) NewABCIClient() (abcicli.Client, error) {
+// NewABCIConsensusClient provides a mock function with no fields
+func (_m *ClientCreator) NewABCIConsensusClient() (abcicli.Client, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for NewABCIClient")
+		panic("no return value specified for NewABCIConsensusClient")
+	}
+
+	var r0 abcicli.Client
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (abcicli.Client, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() abcicli.Client); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(abcicli.Client)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// NewABCIMempoolClient provides a mock function with no fields
+func (_m *ClientCreator) NewABCIMempoolClient() (abcicli.Client, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for NewABCIMempoolClient")
+	}
+
+	var r0 abcicli.Client
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (abcicli.Client, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() abcicli.Client); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(abcicli.Client)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// NewABCIQueryClient provides a mock function with no fields
+func (_m *ClientCreator) NewABCIQueryClient() (abcicli.Client, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for NewABCIQueryClient")
+	}
+
+	var r0 abcicli.Client
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (abcicli.Client, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() abcicli.Client); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(abcicli.Client)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// NewABCISnapshotClient provides a mock function with no fields
+func (_m *ClientCreator) NewABCISnapshotClient() (abcicli.Client, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for NewABCISnapshotClient")
 	}
 
 	var r0 abcicli.Client

--- a/proxy/multi_app_conn.go
+++ b/proxy/multi_app_conn.go
@@ -85,40 +85,73 @@ func (app *multiAppConn) Snapshot() AppConnSnapshot {
 }
 
 func (app *multiAppConn) OnStart() error {
-	c, err := app.abciClientFor(connQuery)
-	if err != nil {
+	if err := app.startQueryClient(); err != nil {
 		return err
 	}
-	app.queryConnClient = c
-	app.queryConn = NewAppConnQuery(c, app.metrics)
-
-	c, err = app.abciClientFor(connSnapshot)
-	if err != nil {
+	if err := app.startSnapshotClient(); err != nil {
 		app.stopAllClients()
 		return err
 	}
-	app.snapshotConnClient = c
-	app.snapshotConn = NewAppConnSnapshot(c, app.metrics)
-
-	c, err = app.abciClientFor(connMempool)
-	if err != nil {
+	if err := app.startMempoolClient(); err != nil {
 		app.stopAllClients()
 		return err
 	}
-	app.mempoolConnClient = c
-	app.mempoolConn = NewAppConnMempool(c, app.metrics)
-
-	c, err = app.abciClientFor(connConsensus)
-	if err != nil {
+	if err := app.startConsensusClient(); err != nil {
 		app.stopAllClients()
 		return err
 	}
-	app.consensusConnClient = c
-	app.consensusConn = NewAppConnConsensus(c, app.metrics)
 
 	// Kill CometBFT if the ABCI application crashes.
 	go app.killTMOnClientError()
 
+	return nil
+}
+
+func (app *multiAppConn) startQueryClient() error {
+	c, err := app.clientCreator.NewABCIQueryClient()
+	if err != nil {
+		return fmt.Errorf("error creating ABCI client (query client): %w", err)
+	}
+	app.queryConnClient = c
+	app.queryConn = NewAppConnQuery(c, app.metrics)
+	return app.startClient(c, connQuery)
+}
+
+func (app *multiAppConn) startSnapshotClient() error {
+	c, err := app.clientCreator.NewABCISnapshotClient()
+	if err != nil {
+		return fmt.Errorf("error creating ABCI client (snapshot client): %w", err)
+	}
+	app.snapshotConnClient = c
+	app.snapshotConn = NewAppConnSnapshot(c, app.metrics)
+	return app.startClient(c, connSnapshot)
+}
+
+func (app *multiAppConn) startMempoolClient() error {
+	c, err := app.clientCreator.NewABCIMempoolClient()
+	if err != nil {
+		return fmt.Errorf("error creating ABCI client (mempool client): %w", err)
+	}
+	app.mempoolConnClient = c
+	app.mempoolConn = NewAppConnMempool(c, app.metrics)
+	return app.startClient(c, connMempool)
+}
+
+func (app *multiAppConn) startConsensusClient() error {
+	c, err := app.clientCreator.NewABCIConsensusClient()
+	if err != nil {
+		return fmt.Errorf("error creating ABCI client (consensus client): %w", err)
+	}
+	app.consensusConnClient = c
+	app.consensusConn = NewAppConnConsensus(c, app.metrics)
+	return app.startClient(c, connConsensus)
+}
+
+func (app *multiAppConn) startClient(c abcicli.Client, conn string) error {
+	c.SetLogger(app.Logger.With("module", "abci-client", "connection", conn))
+	if err := c.Start(); err != nil {
+		return fmt.Errorf("error starting ABCI client (%s client): %w", conn, err)
+	}
 	return nil
 }
 
@@ -178,31 +211,4 @@ func (app *multiAppConn) stopAllClients() {
 			app.Logger.Error("error while stopping snapshot client", "error", err)
 		}
 	}
-}
-
-func (app *multiAppConn) abciClientFor(conn string) (abcicli.Client, error) {
-	var (
-		c   abcicli.Client
-		err error
-	)
-	switch conn {
-	case connConsensus:
-		c, err = app.clientCreator.NewABCIConsensusClient()
-	case connMempool:
-		c, err = app.clientCreator.NewABCIMempoolClient()
-	case connQuery:
-		c, err = app.clientCreator.NewABCIQueryClient()
-	case connSnapshot:
-		c, err = app.clientCreator.NewABCISnapshotClient()
-	default:
-		return nil, fmt.Errorf("unknown ABCI connection type %q", conn)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("error creating ABCI client (%s connection): %w", conn, err)
-	}
-	c.SetLogger(app.Logger.With("module", "abci-client", "connection", conn))
-	if err := c.Start(); err != nil {
-		return nil, fmt.Errorf("error starting ABCI client (%s connection): %w", conn, err)
-	}
-	return c, nil
 }

--- a/proxy/multi_app_conn.go
+++ b/proxy/multi_app_conn.go
@@ -181,7 +181,22 @@ func (app *multiAppConn) stopAllClients() {
 }
 
 func (app *multiAppConn) abciClientFor(conn string) (abcicli.Client, error) {
-	c, err := app.clientCreator.NewABCIClient()
+	var (
+		c   abcicli.Client
+		err error
+	)
+	switch conn {
+	case connConsensus:
+		c, err = app.clientCreator.NewABCIConsensusClient()
+	case connMempool:
+		c, err = app.clientCreator.NewABCIMempoolClient()
+	case connQuery:
+		c, err = app.clientCreator.NewABCIQueryClient()
+	case connSnapshot:
+		c, err = app.clientCreator.NewABCISnapshotClient()
+	default:
+		return nil, fmt.Errorf("unknown ABCI connection type %q", conn)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("error creating ABCI client (%s connection): %w", conn, err)
 	}

--- a/proxy/multi_app_conn_test.go
+++ b/proxy/multi_app_conn_test.go
@@ -26,7 +26,10 @@ func TestAppConns_Start_Stop(t *testing.T) {
 	clientMock.On("Stop").Return(nil).Times(4)
 	clientMock.On("Quit").Return(quitCh).Times(4)
 
-	clientCreatorMock.On("NewABCIClient").Return(clientMock, nil).Times(4)
+	clientCreatorMock.On("NewABCIConsensusClient").Return(clientMock, nil).Times(1)
+	clientCreatorMock.On("NewABCIMempoolClient").Return(clientMock, nil).Times(1)
+	clientCreatorMock.On("NewABCIQueryClient").Return(clientMock, nil).Times(1)
+	clientCreatorMock.On("NewABCISnapshotClient").Return(clientMock, nil).Times(1)
 
 	appConns := NewAppConns(clientCreatorMock, NopMetrics())
 
@@ -65,7 +68,10 @@ func TestAppConns_Failure(t *testing.T) {
 	clientMock.On("Quit").Return(recvQuitCh)
 	clientMock.On("Error").Return(errors.New("EOF")).Once()
 
-	clientCreatorMock.On("NewABCIClient").Return(clientMock, nil)
+	clientCreatorMock.On("NewABCIConsensusClient").Return(clientMock, nil)
+	clientCreatorMock.On("NewABCIMempoolClient").Return(clientMock, nil)
+	clientCreatorMock.On("NewABCIQueryClient").Return(clientMock, nil)
+	clientCreatorMock.On("NewABCISnapshotClient").Return(clientMock, nil)
 
 	appConns := NewAppConns(clientCreatorMock, NopMetrics())
 

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -1083,7 +1083,10 @@ func TestPrepareProposalErrorOnPrepareProposalError(t *testing.T) {
 	cm.On("PrepareProposal", mock.Anything, mock.Anything).Return(nil, errors.New("an injected error")).Once()
 	cm.On("Stop").Return(nil)
 	cc := &pmocks.ClientCreator{}
-	cc.On("NewABCIClient").Return(cm, nil)
+	cc.On("NewABCIConsensusClient").Return(cm, nil)
+	cc.On("NewABCIMempoolClient").Return(cm, nil)
+	cc.On("NewABCIQueryClient").Return(cm, nil)
+	cc.On("NewABCISnapshotClient").Return(cm, nil)
 	proxyApp := proxy.NewAppConns(cc, proxy.NopMetrics())
 	err := proxyApp.Start()
 	require.NoError(t, err)

--- a/test/fuzz/mempool/checktx.go
+++ b/test/fuzz/mempool/checktx.go
@@ -12,7 +12,7 @@ var mempool mempl.Mempool
 func init() {
 	app := kvstore.NewInMemoryApplication()
 	cc := proxy.NewLocalClientCreator(app)
-	client, _ := cc.NewABCIClient()
+	client, _ := cc.NewABCIMempoolClient()
 	err := client.Start()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Stacked on #45.

backport https://github.com/cometbft/cometbft/pull/1141

- Adds `unsyncLocalClient` (no global mutex; callback behind `atomic.Pointer`).
- Splits `ClientCreator` into 4 per-conn methods: consensus / mempool / query / snapshot.
- Adds `NewConsensusSyncLocalClientCreator` (locking consensus, lock-free elsewhere) and `NewUnsyncLocalClientCreator` (all lock-free) for cosmos-sdk + ethermint callers.
- `multi_app_conn` dispatches per-conn factories by connection name.
- Tests: concurrent CheckTx parallelism (race-checked), callback churn under SetResponseCallback, ConsensusSync conn-type split contract.

Eliminates application-wide mutex contention observed on the mempool ABCI connection
